### PR TITLE
Update vulnerable dependencies to latest compatible versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 	implementation("org.apache.avro:avro-compiler:1.11.3") { exclude("org.slf4j") }
 	implementation("org.apache.commons:commons-text:1.10.0")
 	implementation("org.json:json:20231013")
-	implementation("org.kohsuke", "github-api", "1.314")
+	implementation("org.kohsuke", "github-api", "1.317")
 	testImplementation("junit", "junit", "4.13.2")
 	testImplementation("org.assertj", "assertj-core", "3.24.2")
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing. To help review your contribution in the best possible way, please fill out the template below.
-->
## What is the purpose of the change

My team wants to use this plugin in our everyday work, however our company have very strict policy about using IntelliJ plugins and one of the requirements is that it must pass BlackDuck scan by not having any dependencies which introduce a Security Risk.
Latest released version 213.5.3 had following vulnerable dependencies:

**High Security Risk:**
- Apache Avro 1.11.1 - Transitive dependency of Avro Compiler 1.11.1
- JSON-java 20230227

**Medium Security Risk:**
- Jackson-databind 2.14.0 - Transitive dependency of Avro Compiler 1.11.1

**No Security Risk, but Operational Risk (Medium or lower):**
- Apache Velocity Engine 2.3 - Transitive dependency of Avro Compuler 1.11.1 (No remedy at this moment, but it doesn't pose a Security Risk according to BlackDuck)
- Github API for Java 1.314
- Apache Commons Text 1.10.0
- Apache Commons Lang 3.12.0 - Transitive dependency of Apache Avro Compiler 1.11.1, Apache Commons Text 1.10.0, Apache Velocity Engine 2.3 and Github API for Java 1.314
- Apache Commons Compress 1.21 - Transitive dependency of Apache Avro 1.11.1
- Apache Commons IO 2.8.0 - Transitive dependency of Github API for Java 1.314
- jackson-core 2.14.0 - Transitive dependency of Apache Avro 1.11.1
- jackson-annotations 2.14.0 - Transitive dependency of jackson-databind 2.14.0
- Apache Avro Compiler 1.11.1

**Note:** Most important for BlackDuck is Security Risk, however I've updated as much as I could to avoid the situation that something will come back at us.

## Verifying this change

I've verified this change by executing tests that are in the project.

<!--
PS: meaningful commit messages are much appreciated. Preferably, they follow the guidelines from [How to write a good git commit message](https://cbea.ms/git-commit/#seven-rules):
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Capitalize the subject line
  4. Do not end the subject line with a period
  5. Use the imperative mood in the subject line
  6. Wrap the body at 72 characters
  7. Use the body to explain "what" and "why", not "how"
-->
